### PR TITLE
fix(asyncio): fix asyncio problems

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,5 +67,28 @@ jobs:
       run: poetry install -n --all-extras --with test --with dev
     - name: Run mypy
       run: poetry run mypy --config-file mypy.ini pynamodb
+
+  flake8:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.11
+    - name: Install poetry
+      uses: abatilo/actions-poetry@v4
+    - name: Setup a local virtual environment (if no poetry.toml file)
+      run: |
+        poetry config virtualenvs.create true --local
+        poetry config virtualenvs.in-project true --local
+    - uses: actions/cache@v3
+      name: Define a cache for the virtual environment based on the dependencies lock file
+      with:
+        path: ./.venv
+        key: venv-${{ hashFiles('poetry.lock') }}
+    - name: Install the project dependencies
+      run: poetry install -n --all-extras --with test --with dev
     - name: Run flake8 async rules
       run: poetry run flake8 --select=ASYNC pynamodb

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,3 +67,5 @@ jobs:
       run: poetry install -n --all-extras --with test --with dev
     - name: Run mypy
       run: poetry run mypy --config-file mypy.ini pynamodb
+    - name: Run flake8 async rules
+      run: poetry run flake8 --select=ASYNC pynamodb

--- a/poetry.lock
+++ b/poetry.lock
@@ -199,6 +199,27 @@ files = [
 frozenlist = ">=1.1.0"
 
 [[package]]
+name = "anyio"
+version = "4.8.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+optional = true
+python-versions = ">=3.9"
+files = [
+    {file = "anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a"},
+    {file = "anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a"},
+]
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
+
+[package.extras]
+doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21)"]
+trio = ["trio (>=0.26.1)"]
+
+[[package]]
 name = "attrs"
 version = "25.1.0"
 description = "Classes Without Boilerplate"
@@ -1236,6 +1257,17 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
 ]
 
 [[package]]
@@ -2368,10 +2400,10 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-asyncio = ["aioboto3", "aioitertools", "types-aioboto3"]
+asyncio = ["aioboto3", "aioitertools", "anyio", "types-aioboto3"]
 signals = ["blinker"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "d6ec805b0f7d1c620dec6be793430d7b134d17f02ab811e56069ed6e890e91ff"
+content-hash = "e3b01595be16805a8892ac286d68928e8f179f8fa67ca9ca39e7f4567d3369a3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -418,6 +418,39 @@ files = [
 mypy = ["mypy"]
 
 [[package]]
+name = "flake8"
+version = "7.1.2"
+description = "the modular source code checker: pep8 pyflakes and co"
+optional = false
+python-versions = ">=3.8.1"
+files = [
+    {file = "flake8-7.1.2-py2.py3-none-any.whl", hash = "sha256:1cbc62e65536f65e6d754dfe6f1bada7f5cf392d6f5db3c2b85892466c3e7c1a"},
+    {file = "flake8-7.1.2.tar.gz", hash = "sha256:c586ffd0b41540951ae41af572e6790dbd49fc12b3aa2541685d253d9bd504bd"},
+]
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.12.0,<2.13.0"
+pyflakes = ">=3.2.0,<3.3.0"
+
+[[package]]
+name = "flake8-async"
+version = "25.2.3"
+description = "A highly opinionated flake8 plugin for Trio-related problems."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "flake8_async-25.2.3-py3-none-any.whl", hash = "sha256:a602b24dcb1fbaaa77229fb31d64657ac28c325672081d7e9910606947dbe034"},
+    {file = "flake8_async-25.2.3.tar.gz", hash = "sha256:11e33963e5cbe188f3c4958898754dd761bc3c2758fe6b19d59cd38bd8dc2a4f"},
+]
+
+[package.dependencies]
+libcst = ">=1.0.1"
+
+[package.extras]
+flake8 = ["flake8 (>=6)"]
+
+[[package]]
 name = "freezegun"
 version = "1.5.1"
 description = "Let your Python tests travel through time"
@@ -589,6 +622,68 @@ python-versions = ">=3.7"
 files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
+
+[[package]]
+name = "libcst"
+version = "1.6.0"
+description = "A concrete syntax tree with AST-like properties for Python 3.0 through 3.13 programs."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "libcst-1.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2f02d0da6dfbad44e6ec4d1e5791e17afe95d9fe89bce4374bf109fd9c103a50"},
+    {file = "libcst-1.6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48406225378ee9208edb1e5a10451bea810262473af1a2f2473737fd16d34e3a"},
+    {file = "libcst-1.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8bf59a21e9968dc4e7c301fac660bf54bc7d4dcadc0b1abf31b1cac34e800555"},
+    {file = "libcst-1.6.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d65550ac686bff9395398afacbc88fe812363703a4161108e8a6db066d30b96e"},
+    {file = "libcst-1.6.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5ac6d68364031f0b554d8920a69b33f25ec6ef351fa31b4e8f3676abb729ce36"},
+    {file = "libcst-1.6.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0c0fb2f7b74605832cc38d79e9d104f92a8aaeec7bf8f2759b20c5ba3786a321"},
+    {file = "libcst-1.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:1bd11863889b630fe41543b4eb5e2dd445447a7f89e6b58229e83c9e52a74942"},
+    {file = "libcst-1.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a9e71a046b4a91950125967f5ee67389f25a2511103e5595508f0591a5f50bc0"},
+    {file = "libcst-1.6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df3f452e074893dfad7746a041caeb3cde75bd9fbca4ea7b223012e112d1da8c"},
+    {file = "libcst-1.6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31e45f88d4a9a8e5b690ed14a564fcbace14b10f5e7b6797d6d97f4226b395da"},
+    {file = "libcst-1.6.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1bd00399d20bf93590b6f02647f8be08e2b730e050e6b7360f669254e69c98f5"},
+    {file = "libcst-1.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d25132f24edc24895082589645dbb8972c0eff6c9716ff71932fa72643d7c74f"},
+    {file = "libcst-1.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:38f3f25d4f5d8713cdb6a7bd41d75299de3c2416b9890a34d9b05417b8e64c1d"},
+    {file = "libcst-1.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:91242ccbae6e7a070b33ebe03d3677c54bf678653538fbaa89597a59e4a13b2d"},
+    {file = "libcst-1.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cd2b28688dabf0f7a166b47ab1c7d5c0b6ef8c9a05ad932618471a33fe591a4a"},
+    {file = "libcst-1.6.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a12a4766ce5874ccb31a1cc095cff47e2fb35755954965fe77458d9e5b361a8"},
+    {file = "libcst-1.6.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfcd78a5e775f155054ed50d047a260cd23f0f6a89ef2a57e10bdb9c697680b8"},
+    {file = "libcst-1.6.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5786240358b122ad901bb0b7e6b7467085b2317333233d7c7d7cac46388fbd77"},
+    {file = "libcst-1.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c527472093b5b64ffa65d33c472da38952827abbca18c786d559d6d6122bc891"},
+    {file = "libcst-1.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:63a8893dfc344b9b08bfaf4e433b16a7e2e9361f8362fa73eaecc4d379c328ba"},
+    {file = "libcst-1.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:4cd011fcd79b76be216440ec296057780223674bc2566662c4bc50d3c5ecd58e"},
+    {file = "libcst-1.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:96506807dc01c9efcea8ab57d9ea18fdc87b85514cc8ee2f8568fab6df861f02"},
+    {file = "libcst-1.6.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dac722aade8796a1e78662c3ed424f0ab9f1dc0e8fdf3088610354cdd709e53f"},
+    {file = "libcst-1.6.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b8370d0f7092a17b7fcda0e1539d0162cf35a0c19af94842b09c9dddc382acd"},
+    {file = "libcst-1.6.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8e4fcd791cab0fe8287b6edd0d78512b6475b87d906562a5d2d0999cb6d23b8d"},
+    {file = "libcst-1.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3fb953fc0155532f366ff40f6a23f191250134d6928e02074ae4eb3531fa6c30"},
+    {file = "libcst-1.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2f3c85602e5a6d3aec0a8fc74230363f943004d7c2b2a6a1c09b320b61692241"},
+    {file = "libcst-1.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:c4486921bebd33d67bbbd605aff8bfaefd2d13dc73c20c1fde2fb245880b7fd6"},
+    {file = "libcst-1.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b3d274115d134a550fe8a0b38780a28a659d4a35ac6068c7c92fffe6661b519c"},
+    {file = "libcst-1.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d45513f6cd3dbb2a80cf21a53bc6e6e560414edea17c474c784100e10aebe921"},
+    {file = "libcst-1.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8c70a124d7a7d326abdc9a6261013c57d36f21c6c6370de5dd3e6a040c4ee5e"},
+    {file = "libcst-1.6.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdc95df61838d708adb37e18af1615491f6cac59557fd11077664dd956fe4528"},
+    {file = "libcst-1.6.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:05c32de72553cb93ff606c7d2421ce1eab1f0740c8c4b715444e2ae42f42b1b6"},
+    {file = "libcst-1.6.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:69b705f5b1faa66f115ede52a970d7613d3a8fb988834f853f7fb46870a041d2"},
+    {file = "libcst-1.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:984512829a80f963bfc1803342219a4264a8d4206df0a30eae9bce921357a938"},
+    {file = "libcst-1.6.0.tar.gz", hash = "sha256:e80ecdbe3fa43b3793cae8fa0b07a985bd9a693edbe6e9d076f5422ecadbf0db"},
+]
+
+[package.dependencies]
+pyyaml = ">=5.2"
+
+[package.extras]
+dev = ["Sphinx (>=5.1.1)", "black (==24.8.0)", "build (>=0.10.0)", "coverage[toml] (>=4.5.4)", "fixit (==2.1.0)", "flake8 (==7.1.1)", "hypothesis (>=4.36.0)", "hypothesmith (>=0.0.4)", "jinja2 (==3.1.5)", "jupyter (>=1.0.0)", "maturin (>=1.7.0,<1.8)", "nbsphinx (>=0.4.2)", "prompt-toolkit (>=2.0.9)", "pyre-check (==0.9.18)", "setuptools-rust (>=1.5.2)", "setuptools_scm (>=6.0.1)", "slotscheck (>=0.7.1)", "sphinx-rtd-theme (>=0.4.3)", "ufmt (==2.8.0)", "usort (==1.0.8.post1)"]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 
 [[package]]
@@ -919,6 +1014,28 @@ files = [
 ]
 
 [[package]]
+name = "pycodestyle"
+version = "2.12.1"
+description = "Python style guide checker"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3"},
+    {file = "pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"},
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.2.0"
+description = "passive checker of Python programs"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
+    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.4"
 description = "pytest: simple powerful testing with Python"
@@ -1003,6 +1120,68 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
+]
 
 [[package]]
 name = "ruff"
@@ -2195,4 +2374,4 @@ signals = ["blinker"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "07b6ed5c58f98749ad1401a34733b39e9237d154e353d484cbc6f3b9d074a7dd"
+content-hash = "d6ec805b0f7d1c620dec6be793430d7b134d17f02ab811e56069ed6e890e91ff"

--- a/pynamodb/asyncio/batch_get.py
+++ b/pynamodb/asyncio/batch_get.py
@@ -20,7 +20,7 @@ class BatchGetIterator(typing.AsyncIterator[_T]):
         self.unprocessed_batch_items = list(keys)
         self.consistent_read = consistent_read
         self.attributes_to_get = attributes_to_get
-        self.current_batch: List[Dict[str, Any]] = []
+        self.current_batch: list[dict[str, Any]] = []
 
     def __aiter__(self):
         return self

--- a/pynamodb/asyncio/batch_get.py
+++ b/pynamodb/asyncio/batch_get.py
@@ -1,6 +1,7 @@
+import asyncio
 import typing
 
-from typing import List, Dict, Any, TypeVar, Coroutine
+from typing import List, Dict, Any, TypeVar
 
 from aioitertools.asyncio import as_completed
 from more_itertools import chunked
@@ -14,7 +15,7 @@ _T = TypeVar("_T", bound="Model")
 
 class BatchGetIterator(typing.AsyncIterator[_T]):
 
-    def __init__(self, model_cls: _T, keys: typing.Iterable, consistent_read: bool | None = None, attributes_to_get: list | None = None):
+    def __init__(self, model_cls: typing.Type[_T], keys: typing.Iterable, consistent_read: bool | None = None, attributes_to_get: typing.Sequence[str] | None = None):
         self.model_cls = model_cls
         self.unprocessed_batch_items = list(keys)
         self.consistent_read = consistent_read
@@ -42,6 +43,7 @@ class BatchGetIterator(typing.AsyncIterator[_T]):
         # First check if we have items awaiting to be processed
         if self.current_batch:
             item = self.current_batch.pop(0)
+            await asyncio.sleep(0)
             return self.model_cls.from_raw_data(item)
 
         # Check if we have unprocessed items

--- a/pynamodb/asyncio/batch_get.py
+++ b/pynamodb/asyncio/batch_get.py
@@ -1,0 +1,60 @@
+import typing
+
+from typing import List, Dict, Any, TypeVar, Coroutine
+
+from aioitertools.asyncio import as_completed
+from more_itertools import chunked
+
+from pynamodb.constants import BATCH_GET_PAGE_LIMIT
+
+if typing.TYPE_CHECKING:
+    from pynamodb.models import Model # noqa: F401
+
+_T = TypeVar("_T", bound="Model")
+
+class BatchGetIterator(typing.AsyncIterator[_T]):
+
+    def __init__(self, model_cls: _T, keys: typing.Iterable, consistent_read: bool | None = None, attributes_to_get: list | None = None):
+        self.model_cls = model_cls
+        self.unprocessed_batch_items = list(keys)
+        self.consistent_read = consistent_read
+        self.attributes_to_get = attributes_to_get
+        self.current_batch: List[Dict[str, Any]] = []
+
+    def __aiter__(self):
+        return self
+
+    def _get_coroutines(self, unprocessed_batch_items) -> list[typing.Awaitable]:
+        """Split unprocessed batch items into chunks and create coroutines for each chunk."""
+        serialized_keys = list(self.model_cls._batch_serialize_keys(unprocessed_batch_items))
+        return [
+            self.model_cls._async_batch_get_item(
+                chunk, self.consistent_read, self.attributes_to_get
+            )
+            for chunk in chunked(serialized_keys, BATCH_GET_PAGE_LIMIT)
+        ]
+
+    @property
+    def timeout(self) -> int:
+        return self.model_cls.Meta.connect_timeout_seconds + self.model_cls.Meta.read_timeout_seconds
+
+    async def __anext__(self) -> _T:
+        # First check if we have items awaiting to be processed
+        if self.current_batch:
+            item = self.current_batch.pop(0)
+            return self.model_cls.from_raw_data(item)
+
+        # Check if we have unprocessed items
+        if self.unprocessed_batch_items:
+            # Process next batch
+            coros = self._get_coroutines(self.unprocessed_batch_items)
+            self.unprocessed_batch_items = []
+            async for items, unprocessed_keys in as_completed(coros, timeout=self.timeout):
+                # Add unprocessed items back to the queue
+                if unprocessed_keys:
+                    self.unprocessed_batch_items.extend(unprocessed_keys)
+                if items:
+                    self.current_batch.extend(items)
+            if self.current_batch or self.unprocessed_batch_items:
+                return await self.__anext__()
+        raise StopAsyncIteration

--- a/pynamodb/asyncio/batch_write.py
+++ b/pynamodb/asyncio/batch_write.py
@@ -101,7 +101,7 @@ class AsyncBatchWrite(typing.Generic[_T], typing.AsyncContextManager["AsyncBatch
         The cleanup operation is shielded from cancellation and has a timeout to prevent hanging.
         If the cleanup times out, any remaining operations will be lost.
         """
-        async with anyio.fail_after(self.CLEANUP_TIMEOUT, shield=True): # noqa: ASYNC102 - this is handled but flake8 can't detect it
+        with anyio.fail_after(self.CLEANUP_TIMEOUT, shield=True):
             await self.commit()
 
     def _to_process_tasks(self) -> typing.Iterable[

--- a/pynamodb/asyncio/batch_write.py
+++ b/pynamodb/asyncio/batch_write.py
@@ -1,6 +1,7 @@
 import typing
 
 import asyncio
+import anyio
 
 from aioitertools.asyncio import as_completed
 from more_itertools.more import ichunked
@@ -30,6 +31,11 @@ class AsyncBatchWrite(typing.Generic[_T], typing.AsyncContextManager["AsyncBatch
     This class provides an interface for batched write operations (put/delete)
     that are executed asynchronously when the context manager exits.
     """
+
+    # Default timeout for cleanup operations: 
+    # - 5 seconds per item (DynamoDB default) * max batch size
+    # - Additional buffer for retries and network latency
+    CLEANUP_TIMEOUT = BATCH_WRITE_PAGE_LIMIT * 5 + 30  # seconds
 
     def __init__(self, model: typing.Type[_T], auto_commit: bool = True):
         self.model = model
@@ -89,8 +95,40 @@ class AsyncBatchWrite(typing.Generic[_T], typing.AsyncContextManager["AsyncBatch
         exc_val: typing.Optional[BaseException],
         exc_tb: typing.Optional[typing.Any],
     ) -> None:
-        """Exit the async context manager and commit pending operations."""
-        await self.commit()
+        """
+        Exit the async context manager and commit pending operations.
+        
+        The cleanup operation is shielded from cancellation and has a timeout to prevent hanging.
+        If the cleanup times out, any remaining operations will be lost.
+        """
+        async with anyio.fail_after(self.CLEANUP_TIMEOUT, shield=True): # noqa: ASYNC102 - this is handled but flake8 can't detect it
+            await self.commit()
+
+    def _to_process_tasks(self) -> typing.Iterable[
+            typing.Coroutine[
+                typing.Any,
+                typing.Any,
+                typing.Optional[typing.Dict[str, typing.Any]],
+            ]
+    ]:
+        for chunk in ichunked(self.pending_operations, BATCH_WRITE_PAGE_LIMIT):
+            put_items: typing.List[SerializedItem] = []
+            delete_items: typing.List[SerializedItem] = []
+
+            for item in chunk:
+                if item.get("action") == PUT:
+                    put_items.append(item["item"].serialize())
+                elif item.get("action") == DELETE:
+                    delete_items.append(item["item"]._get_keys())
+                elif PUT_REQUEST in item:
+                    put_items.append(item[PUT_REQUEST]["ITEM"])
+                elif DELETE_REQUEST in item:
+                    delete_items.append(item[DELETE_REQUEST]["KEY"])
+
+            yield self.model._async_get_connection().batch_write_item(
+                put_items=put_items, delete_items=delete_items
+            )
+
 
     async def commit(self) -> None:
         """
@@ -100,45 +138,19 @@ class AsyncBatchWrite(typing.Generic[_T], typing.AsyncContextManager["AsyncBatch
             PutError: If the maximum retry attempts are exceeded
         """
 
-        async def _tasks() -> typing.AsyncIterator[
-            typing.Coroutine[
-                typing.Any,
-                typing.Any,
-                typing.Optional[typing.Dict[str, typing.Any]],
-            ]
-        ]:
-            for chunk in ichunked(self.pending_operations, BATCH_WRITE_PAGE_LIMIT):
-                put_items: typing.List[SerializedItem] = []
-                delete_items: typing.List[SerializedItem] = []
-
-                for item in chunk:
-                    if item.get("action") == PUT:
-                        put_items.append(item["item"].serialize())
-                    elif item.get("action") == DELETE:
-                        delete_items.append(item["item"]._get_keys())
-                    elif PUT_REQUEST in item:
-                        put_items.append(item[PUT_REQUEST]["ITEM"])
-                    elif DELETE_REQUEST in item:
-                        delete_items.append(item[DELETE_REQUEST]["KEY"])
-
-                yield self.model._async_get_connection().batch_write_item(
-                    put_items=put_items, delete_items=delete_items
-                )
-                await asyncio.sleep(0)
-            self.pending_operations = []
-
         retries = 0
-        unprocessed_batch_items = list(self.pending_operations)
-
-        while unprocessed_batch_items and retries < self.model.Meta.max_retry_attempts:
-            async for data in as_completed([i async for i in _tasks()]):
+        while self.pending_operations and retries < self.model.Meta.max_retry_attempts:
+            next_cycle_items = []
+            async for data in as_completed(self._to_process_tasks()):
                 if data is None:
                     continue
                 unprocessed_items = data.get(UNPROCESSED_ITEMS, {}).get(
                     self.model.Meta.table_name, []
                 )
-                self.pending_operations.extend(unprocessed_items)
+                next_cycle_items.extend(unprocessed_items)
+            self.pending_operations = next_cycle_items
             retries += 1
             await asyncio.sleep(0)
         if self.pending_operations:
             raise PutError("Failed to batch write items: max_retry_attempts exceeded")
+        await asyncio.sleep(0)

--- a/pynamodb/asyncio/batch_write.py
+++ b/pynamodb/asyncio/batch_write.py
@@ -56,6 +56,7 @@ class AsyncBatchWrite(typing.Generic[_T], typing.AsyncContextManager["AsyncBatch
             if self.auto_commit:
                 await self.commit()
         self.pending_operations.append({"action": PUT, "item": put_item})
+        await asyncio.sleep(0)
 
     async def delete(self, del_item: _T) -> None:
         """
@@ -75,9 +76,11 @@ class AsyncBatchWrite(typing.Generic[_T], typing.AsyncContextManager["AsyncBatch
             if self.auto_commit:
                 await self.commit()
         self.pending_operations.append({"action": DELETE, "item": del_item})
+        await asyncio.sleep(0)
 
     async def __aenter__(self) -> "AsyncBatchWrite[_T]":
         """Enter the async context manager."""
+        await asyncio.sleep(0)
         return self
 
     async def __aexit__(

--- a/pynamodb/asyncio/connection.py
+++ b/pynamodb/asyncio/connection.py
@@ -94,11 +94,11 @@ except ImportError:
 
 
 class AsyncPynamoDBContext(AbstractAsyncContextManager):
-    CLEANUP_TIMEOUT = 10
 
-    def __init__(self):
+    def __init__(self, cleanup_timeout: int = 10):
         self._context_token = None
         self._client_token = None
+        self._cleanup_timeout = cleanup_timeout
 
     async def __aenter__(self):
         stack, token = await create_stack()
@@ -108,7 +108,7 @@ class AsyncPynamoDBContext(AbstractAsyncContextManager):
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         stack = get_stack()
-        with anyio.fail_after(self.CLEANUP_TIMEOUT, shield=True):
+        with anyio.fail_after(self._cleanup_timeout, shield=True):
             if not stack:
                 return await asyncio.sleep(0)
             await stack.__aexit__(exc_type, exc_val, exc_tb)

--- a/pynamodb/asyncio/connection.py
+++ b/pynamodb/asyncio/connection.py
@@ -2,6 +2,7 @@ import logging
 import threading
 import typing
 from contextlib import AbstractAsyncContextManager
+from contextvars import Token
 
 import aioboto3
 import asyncio
@@ -94,6 +95,9 @@ except ImportError:
 
 
 class AsyncPynamoDBContext(AbstractAsyncContextManager):
+    _context_token: Token[typing.Any] | None
+    _client_token: Token[typing.Any] | None
+    _cleanup_timeout: int
 
     def __init__(self, cleanup_timeout: int = 10):
         self._context_token = None

--- a/pynamodb/asyncio/connection.py
+++ b/pynamodb/asyncio/connection.py
@@ -1,20 +1,21 @@
-import contextlib
 import logging
 import threading
 import typing
 from contextlib import AbstractAsyncContextManager
-from contextvars import ContextVar
 
 import aioboto3
 import asyncio
+
+import anyio
 import types_aiobotocore_dynamodb
 from aiobotocore.config import AioConfig
 from botocore.exceptions import ClientError, BotoCoreError
 
+from pynamodb.asyncio.context.clients import get_or_create_client, create_client_stack, reset_client_stack
+from pynamodb.asyncio.context.stack import create_stack, get_stack, reset_stack
 from pynamodb.connection.abstracts import AbstractConnection
 from pynamodb.connection.base import BOTOCORE_EXCEPTIONS, MetaTable
 from pynamodb.constants import (
-    SERVICE_NAME,
     DELETE_ITEM,
     UPDATE_ITEM,
     ITEM,
@@ -81,10 +82,6 @@ from pynamodb.expressions.update import Action
 
 thread_local = threading.local()
 
-ClientContext: ContextVar[contextlib.AsyncExitStack | None] = ContextVar(
-    "ClientContext", default=None
-)
-
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
@@ -97,30 +94,30 @@ except ImportError:
 
 
 class AsyncPynamoDBContext(AbstractAsyncContextManager):
+    CLEANUP_TIMEOUT = 10
+
     def __init__(self):
-        current_ctx = ClientContext.get()
-        if current_ctx is not None:
-            raise RuntimeError(
-                "You're already inside an async context. Only a single `AsyncPynamoDB` context is allowed."
-            )
+        _, token = create_stack(fail_if_exists=True)
+        self._context_token = token
+        self._client_token = None
 
-        stack = contextlib.AsyncExitStack()
-        self._token = ClientContext.set(stack)
-
-    def __aenter__(self):
-        stack = ClientContext.get()
+    async def __aenter__(self):
+        stack = get_stack()
+        self._client_token = await create_client_stack()
         if not stack:
             raise RuntimeError(
                 "You're not inside an async context. You must use `AsyncPynamoDB` to create a connection."
             )
-        return stack.__aenter__()
+        return await stack.__aenter__()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        stack = ClientContext.get()
-        if not stack:
-            return
-        await stack.__aexit__(exc_type, exc_val, exc_tb)
-        ClientContext.reset(self._token)
+        stack = get_stack()
+        async with anyio.fail_after(self.CLEANUP_TIMEOUT, shield=True): # noqa: ASYNC102 - this is handled but flake8 can't detect it
+            if not stack:
+                return await asyncio.sleep(0)
+            await stack.__aexit__(exc_type, exc_val, exc_tb)
+            await reset_stack(self._context_token)
+            await reset_client_stack(self._client_token)
 
 
 class AsyncConnection(AbstractConnection[aioboto3.Session]):
@@ -200,30 +197,18 @@ class AsyncConnection(AbstractConnection[aioboto3.Session]):
         return data
 
     async def get_client(self) -> types_aiobotocore_dynamodb.DynamoDBClient:
-        if not self._client or (
-            self._client._request_signer
-            and not self._client._request_signer._credentials
-        ):
-            config = AioConfig(
-                parameter_validation=False,  # Disable unnecessary validation for performance
-                connect_timeout=self._connect_timeout_seconds,
-                read_timeout=self._read_timeout_seconds,
-                max_pool_connections=self._max_pool_connections,
-                retries={
-                    "total_max_attempts": 1 + self._max_retry_attempts_exception,
-                    "mode": "standard",
-                },
-            )
-            stack = ClientContext.get()
-            if stack is None:
-                raise RuntimeError(
-                    "You're not inside an async context. You must use `AsyncPynamoDB` to create a connection."
-                )
-            client = self.session.client(
-                SERVICE_NAME, region_name=self.region, endpoint_url=self.host, config=config
-            ) # type: ignore[call-overload]
-            self._client = await stack.enter_async_context(client)
-        return typing.cast(types_aiobotocore_dynamodb.DynamoDBClient, self._client)
+        config = AioConfig(
+            parameter_validation=False,  # Disable unnecessary validation for performance
+            connect_timeout=self._connect_timeout_seconds,
+            read_timeout=self._read_timeout_seconds,
+            max_pool_connections=self._max_pool_connections,
+            retries={
+                "total_max_attempts": 1 + self._max_retry_attempts_exception,
+                "mode": "standard",
+            },
+        )
+        client = await get_or_create_client(session=self.session, connection_id=self._id, region=self.region, host=self.host, config=config)
+        return typing.cast(types_aiobotocore_dynamodb.DynamoDBClient, client)
 
     async def delete_item(
         self,

--- a/pynamodb/asyncio/context/clients.py
+++ b/pynamodb/asyncio/context/clients.py
@@ -1,0 +1,74 @@
+import asyncio
+from contextvars import ContextVar, Token
+
+import aioboto3
+import types_aiobotocore_dynamodb
+from aiobotocore.config import AioConfig
+
+from pynamodb.asyncio.context.stack import add_to_stack
+from pynamodb.constants import SERVICE_NAME
+
+_ClientsContext: ContextVar[dict | None] = ContextVar(
+    "_ClientsContext", default=None
+)
+_lock = asyncio.Lock()
+
+async def _get_client(connection_id: str) -> types_aiobotocore_dynamodb.DynamoDBClient | None:
+    async with _lock:
+        clients = _ClientsContext.get()
+        if clients is None:
+            return None
+        return clients.get(connection_id)
+
+async def _create_client(
+    session: aioboto3.Session,
+    connection_id: str,
+    region: str,
+    host: str,
+    config: AioConfig,
+) -> types_aiobotocore_dynamodb.DynamoDBClient:
+    async with _lock:
+        clients = _ClientsContext.get()
+        if clients is None:
+            raise RuntimeError("Can't create a client outside an async context")
+        # Check if the client is already in the stack
+        if connection_id in clients:
+            return clients[connection_id]
+
+        # Create the client
+        client = await add_to_stack(session.client(
+            SERVICE_NAME,
+            region_name=region,
+            endpoint_url=host,
+            config=config,
+        ))
+
+        # Add the client to the stack
+        clients[connection_id] = client
+        _ClientsContext.set(clients)
+        return client
+
+async def get_or_create_client(
+    *,
+    session: aioboto3.Session,
+    connection_id: str,
+    region: str,
+    host: str,
+    config: AioConfig,
+) -> types_aiobotocore_dynamodb.DynamoDBClient:
+    client = await _get_client(connection_id)
+    if client is not None:
+        return client
+    return await _create_client(session, connection_id, region, host, config)
+
+async def create_client_stack() -> Token[dict | None]:
+    async with _lock:
+        clients = _ClientsContext.get()
+        if clients is not None:
+            raise RuntimeError("Trying to create a client stack while one already exists")
+        clients = {}
+        return _ClientsContext.set(clients)
+
+async def reset_client_stack(token: Token[dict | None]) -> None:
+    async with _lock:
+        _ClientsContext.reset(token)

--- a/pynamodb/asyncio/context/clients.py
+++ b/pynamodb/asyncio/context/clients.py
@@ -24,7 +24,7 @@ async def _create_client(
     session: aioboto3.Session,
     connection_id: str,
     region: str,
-    host: str,
+    host: str | None,
     config: AioConfig,
 ) -> types_aiobotocore_dynamodb.DynamoDBClient:
     async with _lock:
@@ -36,12 +36,13 @@ async def _create_client(
             return clients[connection_id]
 
         # Create the client
-        client = await add_to_stack(session.client(
+        _client_cm = session.client(
             SERVICE_NAME,
             region_name=region,
             endpoint_url=host,
             config=config,
-        ))
+        ) # type: ignore[call-overload]
+        client = await add_to_stack(_client_cm)
 
         # Add the client to the stack
         clients[connection_id] = client
@@ -53,7 +54,7 @@ async def get_or_create_client(
     session: aioboto3.Session,
     connection_id: str,
     region: str,
-    host: str,
+    host: str | None,
     config: AioConfig,
 ) -> types_aiobotocore_dynamodb.DynamoDBClient:
     client = await _get_client(connection_id)

--- a/pynamodb/asyncio/context/stack.py
+++ b/pynamodb/asyncio/context/stack.py
@@ -1,0 +1,55 @@
+import asyncio
+import contextlib
+from contextlib import AsyncExitStack
+from contextvars import ContextVar, Token
+from typing import cast, TypeVar, Any, AsyncContextManager
+
+_StackContext: ContextVar[contextlib.AsyncExitStack | None] = ContextVar(
+    "_StackContext", default=None
+)
+_lock = asyncio.Lock()
+
+# Type variable for the return type of __aenter__
+_T = TypeVar("_T")
+
+async def create_stack(fail_if_exists: bool = False) -> tuple[AsyncExitStack, Token[AsyncExitStack | None]]:
+    async with _lock:
+        if fail_if_exists and _StackContext.get() is not None:
+            raise RuntimeError(
+                "You're already inside an async context. Only a single `AsyncPynamoDB` context is allowed."
+            )
+        stack = contextlib.AsyncExitStack()
+        token = _StackContext.set(stack)
+        return cast(contextlib.AsyncExitStack, _StackContext.get()), token
+
+async def add_to_stack(cm: AsyncContextManager[_T]) -> _T:
+    """
+    Add an async context manager to the current exit stack.
+    
+    This function retrieves the current AsyncExitStack from context and adds
+    the provided async context manager to it using enter_async_context.
+    
+    Args:
+        cm: The async context manager to add to the stack
+        
+    Returns:
+        The value returned by the async context manager's __aenter__ method
+        
+    Raises:
+        RuntimeError: If called outside of a valid stack context
+    """
+    async with _lock:
+        stack = _StackContext.get()
+        if stack is None:
+            raise RuntimeError(
+                "No active async context stack found. Call create_stack() first."
+            )
+        # Add the context manager to the stack and return the result of __aenter__
+        return await stack.enter_async_context(cm)
+
+def get_stack() -> AsyncExitStack | None:
+    return _StackContext.get()
+
+async def reset_stack(token: Token[AsyncExitStack | None]) -> None:
+    async with _lock:
+        _StackContext.reset(token)

--- a/pynamodb/asyncio/result_iterator.py
+++ b/pynamodb/asyncio/result_iterator.py
@@ -140,6 +140,7 @@ class AsyncResultIterator(AsyncIterator[_T]):
             self._limit -= 1
         if self._map_fn:
             item = self._map_fn(item)
+        await asyncio.sleep(0)
         return item
 
     async def next(self) -> _T:

--- a/pynamodb/asyncio/transactions.py
+++ b/pynamodb/asyncio/transactions.py
@@ -65,7 +65,7 @@ class AsyncTransaction(AbstractAsyncContextManager):
             exc_val: The instance of the exception that was raised
             exc_tb: The traceback of the exception that was raised
         """
-        async with anyio.fail_after(self.CLEANUP_TIMEOUT, shield=True): # noqa: ASYNC102 - this is handled but flake8 can't detect it
+        with anyio.fail_after(self.CLEANUP_TIMEOUT, shield=True):
             if all(x is None for x in (exc_type, exc_val, exc_tb)):
                 await self._commit()
             await asyncio.sleep(0)

--- a/pynamodb/connection/abstracts.py
+++ b/pynamodb/connection/abstracts.py
@@ -1,4 +1,5 @@
 import abc
+import uuid
 from abc import abstractmethod
 from threading import local
 from typing import Any, Dict, Mapping, Optional, Sequence
@@ -61,6 +62,7 @@ class AbstractConnection(abc.ABC, typing.Generic[T_BotoSession]):
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
     ):
+        self._id = str(uuid.uuid4())
         self._tables: Dict[str, "MetaTable"] = {}
         self.host = host
         self._local = local()

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -25,6 +25,7 @@ from typing import cast
 
 import asyncio
 
+import aioitertools
 from aioitertools.asyncio import as_completed
 from more_itertools import chunked
 
@@ -479,7 +480,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
                 process_item(item)
             ```
         """
-        items = []
+        return_items = []
         unprocessed_batch_items: list[Any] = list(items)
 
         while unprocessed_batch_items:
@@ -498,14 +499,14 @@ class Model(AttributeContainer, metaclass=MetaModel):
                 to_process.extend(unprocessed_items or [])
                 for item in items:
                     if isinstance(item, dict):
-                        items.append(cls.from_raw_data(item))
+                        return_items.append(cls.from_raw_data(item))
                     else:
                         raise ValueError("Got an unexpected type when reading the batch.")
             unprocessed_batch_items = to_process
             # Small delay to prevent tight loops
             await asyncio.sleep(0)
         await asyncio.sleep(0)
-        return items
+        return aioitertools.iter(return_items)
 
     @classmethod
     def batch_write(cls: Type[_T], auto_commit: bool = True) -> BatchWrite[_T]:

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -5,6 +5,7 @@ import time
 import logging
 import warnings
 import sys
+from contextlib import asynccontextmanager
 from copy import deepcopy
 from inspect import getmembers
 from typing import Any, AsyncIterator
@@ -30,6 +31,7 @@ from aioitertools.asyncio import as_completed
 from more_itertools import chunked
 
 from pynamodb._schema import ModelSchema
+from pynamodb.asyncio.batch_get import BatchGetIterator
 from pynamodb.asyncio.batch_write import AsyncBatchWrite
 from pynamodb.asyncio.result_iterator import AsyncResultIterator
 from pynamodb.asyncio.table_connection import AsyncTableConnection
@@ -444,12 +446,12 @@ class Model(AttributeContainer, metaclass=MetaModel):
                 yield {hash_key_attribute.attr_name: hash_key_ser}
 
     @classmethod
-    async def async_batch_get(
+    def async_batch_get(
         cls: Type[_T],
         items: Iterable[Union[_KeyType, Iterable[_KeyType]]],
         consistent_read: Optional[bool] = None,
         attributes_to_get: Optional[Sequence[str]] = None,
-    ) -> AsyncIterator[_T]:
+    ) -> BatchGetIterator[_T]:
         """Retrieve multiple items from DynamoDB in batches.
 
         This method handles pagination and retries for unprocessed items automatically.
@@ -471,42 +473,18 @@ class Model(AttributeContainer, metaclass=MetaModel):
             ```python
             # For a table with only hash key
             keys = ["id1", "id2", "id3"]
-            async for item in wrapper.batch_get(keys):
+            async for item in Model.async_batch_get(keys):
                 process_item(item)
 
             # For a table with hash and range key
             keys = [("id1", "sort1"), ("id2", "sort2")]
-            async for item in wrapper.batch_get(keys):
+            async for item in Model.async_batch_get(keys):
                 process_item(item)
             ```
         """
-        return_items = []
-        unprocessed_batch_items: list[Any] = list(items)
+        # Return the iterator
+        return BatchGetIterator(cls, items, consistent_read, attributes_to_get)
 
-        while unprocessed_batch_items:
-            to_process: List[Dict[str, Any]] = []
-
-            # Create tasks for each chunk of keys
-            tasks = [
-                cls._async_batch_get_item(chunk, consistent_read, attributes_to_get)
-                for chunk in chunked(
-                    cls._batch_serialize_keys(unprocessed_batch_items),
-                    BATCH_GET_PAGE_LIMIT,
-                )
-            ]
-            # Process completed tasks
-            async for items, unprocessed_items in as_completed(tasks):
-                to_process.extend(unprocessed_items or [])
-                for item in items:
-                    if isinstance(item, dict):
-                        return_items.append(cls.from_raw_data(item))
-                    else:
-                        raise ValueError("Got an unexpected type when reading the batch.")
-            unprocessed_batch_items = to_process
-            # Small delay to prevent tight loops
-            await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        return aioitertools.iter(return_items)
 
     @classmethod
     def batch_write(cls: Type[_T], auto_commit: bool = True) -> BatchWrite[_T]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,11 @@ aioboto3 = { version = "^13.4.0", optional = true }
 aioitertools = { version = "^0.12.0", optional = true }
 types-aioboto3 = {extras = ["dynamodb"], version = "^13.4.0", optional = true}
 more-itertools = "^10.6.0"
+anyio = { version = "^4.7.0", optional = true }
 
 [tool.poetry.extras]
 signals = ["blinker"]
-asyncio = ["asyncio", "aioboto3", "aioitertools", "types-aioboto3"]
+asyncio = ["asyncio", "aioboto3", "aioitertools", "types-aioboto3", "anyio"]
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ blinker = { version = ">=1.3,<2.0", optional = true }
 aioboto3 = { version = "^13.4.0", optional = true }
 aioitertools = { version = "^0.12.0", optional = true }
 types-aioboto3 = {extras = ["dynamodb"], version = "^13.4.0", optional = true}
-
 more-itertools = "^10.6.0"
 
 [tool.poetry.extras]
@@ -31,6 +30,8 @@ pytest-asyncio = "^0.25.3"
 mypy = "^1.15.0"
 ruff = "^0.9.6"
 ddtrace = "^3.1.0"
+flake8 = "^7.1.2"
+flake8-async = "^25.2.3"
 
 [tool.ruff]
 include = ["pyproject.toml", "pynamodb/**/*.py"]


### PR DESCRIPTION
## Overview
Fix a lot of issues:
```
pynamodb/asyncio/batch_write.py:93:9: ASYNC102 await inside __aexit__ on line 86 must have shielded cancel scope with a timeout.
pynamodb/asyncio/batch_write.py:95:5: ASYNC910 exit from async function with no guaranteed checkpoint or exception since function definition on line 95.
pynamodb/asyncio/batch_write.py:103:9: ASYNC911 exit from async iterable with no guaranteed checkpoint since function definition on line 103.
pynamodb/asyncio/batch_write.py:103:9: ASYNC900 Async generator not allowed, unless transformed by a known decorator (one of: asynccontextmanager, fixture).
pynamodb/asyncio/batch_write.py:124:17: ASYNC911 yield from async iterable with no guaranteed checkpoint since function definition on line 103.
pynamodb/asyncio/connection.py:121:13: ASYNC910 return from async function with no guaranteed checkpoint or exception since function definition on line 118.
pynamodb/asyncio/connection.py:122:9: ASYNC102 await inside __aexit__ on line 118 must have shielded cancel scope with a timeout.
pynamodb/asyncio/connection.py:226:9: ASYNC910 return from async function with no guaranteed checkpoint or exception since function definition on line 202.
pynamodb/asyncio/result_iterator.py:143:9: ASYNC910 return from async function with no guaranteed checkpoint or exception since function definition on line 128.
pynamodb/asyncio/transactions.py:47:9: ASYNC910 return from async function with no guaranteed checkpoint or exception since function definition on line 45.
pynamodb/asyncio/transactions.py:49:5: ASYNC910 exit from async function with no guaranteed checkpoint or exception since function definition on line 49.
pynamodb/asyncio/transactions.py:64:13: ASYNC102 await inside __aexit__ on line 49 must have shielded cancel scope with a timeout.
pynamodb/models.py:446:5: ASYNC911 exit from async iterable with no guaranteed checkpoint since function definition on line 446.
pynamodb/models.py:446:5: ASYNC900 Async generator not allowed, unless transformed by a known decorator (one of: asynccontextmanager, fixture).
pynamodb/models.py:501:25: ASYNC911 yield from async iterable with no guaranteed checkpoint since yield on line 501.
```

Also improve how we interact with context (by using a lock) and stop caching the connections on the class and store on the context instead