### PR TITLE
perf: use task group instead of `as_completed` for batch_get

### DIFF
--- a/pynamodb/asyncio/batch_get.py
+++ b/pynamodb/asyncio/batch_get.py
@@ -1,9 +1,8 @@
 import asyncio
 import typing
 
-from typing import List, Dict, Any, TypeVar
+from typing import Any, TypeVar
 
-from aioitertools.asyncio import as_completed
 from more_itertools import chunked
 
 from pynamodb.constants import BATCH_GET_PAGE_LIMIT
@@ -49,14 +48,20 @@ class BatchGetIterator(typing.AsyncIterator[_T]):
         # Check if we have unprocessed items
         if self.unprocessed_batch_items:
             # Process next batch
-            coros = self._get_coroutines(self.unprocessed_batch_items)
             self.unprocessed_batch_items = []
-            async for items, unprocessed_keys in as_completed(coros, timeout=self.timeout):
-                # Add unprocessed items back to the queue
-                if unprocessed_keys:
-                    self.unprocessed_batch_items.extend(unprocessed_keys)
-                if items:
-                    self.current_batch.extend(items)
+            futures = []
+            async with asyncio.TaskGroup() as tg:
+                for coro in self._get_coroutines(self.unprocessed_batch_items):
+                    futures.append(tg.create_task(coro))
+                    await asyncio.sleep(0)
+            for future in futures:
+                for items, unprocessed_keys in future.result():
+                    # Add unprocessed items back to the queue
+                    if unprocessed_keys:
+                        self.unprocessed_batch_items.extend(unprocessed_keys)
+                    if items:
+                        self.current_batch.extend(items)
+                    await asyncio.sleep(0)
             if self.current_batch or self.unprocessed_batch_items:
                 return await self.__anext__()
         raise StopAsyncIteration


### PR DESCRIPTION
## Overview

In our benchmarks I've realized that the `TaskGroup` performs better than the `as_completed` and there is very little gain of using `as_completed` here if we are required that the batch_get coroutines to complete before finishing a single iteration. 

Also, TaskGroups handle cancellation errors better and gives more safety to the code than `as_completed`